### PR TITLE
Require attribute_url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
     "php": "^7.1",
     "contao-community-alliance/dc-general": "^2.1.0",
     "contao/core-bundle": "^4.4.8",
+    "metamodels/attribute_url": "^2.1",
     "metamodels/core": "^2.1",
     "symfony/dependency-injection": "^3.3 || ^4.0",
     "symfony/http-kernel": "^3.3 || ^4.0"


### PR DESCRIPTION
## Description

The palette definition "url" and the field definition "trim title" are missing, therefore requiring the base attribute.

```
Metapalette definition of palette "url" does not exist
```

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [x] Created tests, if possible
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [x] Checked the changes with phpcq and introduced no new issues
